### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Building using Apache Cordova
 You can also use Apache Cordova to build the app:
 
 ````bash
-zermelo-app$ cordova platform add android
+zermelo-app$ cordova platform add android@4.0.0
 
 zermelo-app$ cordova build
 ````


### PR DESCRIPTION
The build instructions weren't working for me by installing the latest Cordova and latest Cordova Android and by downgrading the version to 4.0.0, the build is working.